### PR TITLE
Revert "Bump nokogiri from 1.18.10 to 1.19.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     minitest (5.27.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.19.3)
+    nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)


### PR DESCRIPTION
Reverts DillonAd/DillonAd.github.io#77

This broke local dev. Nokogiri ended support of Ruby 3.1 with the release of 1.19.* so we are stuck here until the `jekyll/jekyll` image is updated to allow the dependencies to move forward. 